### PR TITLE
Implemented filter logic

### DIFF
--- a/src/scripts/Store.js
+++ b/src/scripts/Store.js
@@ -30,6 +30,10 @@ class Store extends Observable {
       });
     }
 
+    if (this.state.providerFilter) {
+      deals = deals.filter(deal => deal.provider.name.toLowerCase() === this.state.providerFilter)
+    }
+
     return deals;
   }
 

--- a/src/scripts/Store.js
+++ b/src/scripts/Store.js
@@ -31,7 +31,7 @@ class Store extends Observable {
     }
 
     if (this.state.providerFilter) {
-      deals = deals.filter(deal => deal.provider.name.toLowerCase() === this.state.providerFilter)
+      deals = deals.filter(deal => deal.provider.id === this.state.providerFilter)
     }
 
     return deals;

--- a/src/scripts/Store.js
+++ b/src/scripts/Store.js
@@ -15,7 +15,21 @@ class Store extends Observable {
   }
 
   filter() {
-    return this.state.deals;
+    let deals = [...this.state.deals];
+
+    if (this.state.productFilters.length) {
+      deals = deals.filter(deal => {
+        let productTypes = deal.productTypes
+          .filter(type => type != 'Phone')
+          .map(type => type.toLowerCase().indexOf('broadband') > -1
+            ? 'broadband' : type.toLowerCase())
+          .join(',');
+
+        return productTypes === this.state.productFilters.join(',').toLowerCase();
+      });
+    }
+
+    return deals;
   }
 
   setDeals(data) {

--- a/src/scripts/Store.js
+++ b/src/scripts/Store.js
@@ -23,9 +23,10 @@ class Store extends Observable {
           .filter(type => type != 'Phone')
           .map(type => type.toLowerCase().indexOf('broadband') > -1
             ? 'broadband' : type.toLowerCase())
+          .sort()
           .join(',');
 
-        return productTypes === this.state.productFilters.join(',').toLowerCase();
+        return productTypes === this.state.productFilters.sort().join(',').toLowerCase();
       });
     }
 

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -30,4 +30,13 @@ describe("filter", () => {
     expect(sut.deals[2].id).toEqual(4371);
     expect(sut.deals[3].id).toEqual(5459);
   });
+
+  it('should return 4 deals when filtered by broadband and tv', () => {
+    // Act
+    sut.setProductFilter('broadband');
+    sut.setProductFilter('tv');
+
+    // Assert
+    expect(sut.deals.length).toEqual(4);
+  });
 });

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -2,11 +2,15 @@ import Store from "../Store";
 import mockData from "../../../public/db.json";
 
 describe("filter", () => {
-  it("should return all deals when no filters applied", () => {
-    // Arrange
-    const sut = new Store();
-    sut.setDeals(mockData.deals);
+  let sut;
 
+  beforeEach(() => {
+    // Arrange
+    sut = new Store();
+    sut.setDeals(mockData.deals);
+  });
+
+  it("should return all deals when no filters applied", () => {
     // Act
     const result = sut.deals;
 
@@ -16,10 +20,6 @@ describe("filter", () => {
   });
 
   it('should return 4 broadband deals when filtered by broadband', () => {
-    // Arrange
-    const sut = new Store();
-    sut.setDeals(mockData.deals);
-
     // Act
     sut.setProductFilter('broadband');
 

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -38,5 +38,9 @@ describe("filter", () => {
 
     // Assert
     expect(sut.deals.length).toEqual(4);
+    expect(sut.deals[0].id).toEqual(6074);
+    expect(sut.deals[1].id).toEqual(5738);
+    expect(sut.deals[2].id).toEqual(6165);
+    expect(sut.deals[3].id).toEqual(6468);
   });
 });

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -14,4 +14,16 @@ describe("filter", () => {
     expect(result).toEqual(mockData.deals);
     expect(result.length).toEqual(11);
   });
+
+  it('should return 4 broadband deals when filtered by broadband', () => {
+    // Arrange
+    const sut = new Store();
+    sut.setDeals(mockData.deals);
+
+    // Act
+    sut.setProductFilter('broadband');
+
+    // Assert
+    expect(sut.deals.length).toEqual(4);
+  });
 });

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -53,4 +53,12 @@ describe("filter", () => {
     expect(sut.deals.length).toEqual(1);
     expect(sut.deals[0].id).toEqual(4276);
   });
+
+  it('should return 1 deal when filtered by sky provider', () => {
+    // Act
+    sut.setProviderFilter('sky');
+
+    // Assert
+    expect(sut.deals.length).toEqual(1);
+  });
 });

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -25,5 +25,9 @@ describe("filter", () => {
 
     // Assert
     expect(sut.deals.length).toEqual(4);
+    expect(sut.deals[0].id).toEqual(6158);
+    expect(sut.deals[1].id).toEqual(4359);
+    expect(sut.deals[2].id).toEqual(4371);
+    expect(sut.deals[3].id).toEqual(5459);
   });
 });

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -60,5 +60,6 @@ describe("filter", () => {
 
     // Assert
     expect(sut.deals.length).toEqual(1);
+    expect(sut.deals[0].id).toEqual(6468);
   });
 });

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -43,4 +43,14 @@ describe("filter", () => {
     expect(sut.deals[2].id).toEqual(6165);
     expect(sut.deals[3].id).toEqual(6468);
   });
+
+  it('should return 1 deal when filtered by broadband and mobile', () => {
+    // Act
+    sut.setProductFilter('broadband');
+    sut.setProductFilter('mobile');
+
+    // Assert
+    expect(sut.deals.length).toEqual(1);
+    expect(sut.deals[0].id).toEqual(4276);
+  });
 });

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -56,7 +56,7 @@ describe("filter", () => {
 
   it('should return 1 deal when filtered by sky provider', () => {
     // Act
-    sut.setProviderFilter('sky');
+    sut.setProviderFilter(1);
 
     // Assert
     expect(sut.deals.length).toEqual(1);
@@ -65,7 +65,7 @@ describe("filter", () => {
 
   it('should return 2 deals when filtered by BT, broadband and tv', () => {
     // Act
-    sut.setProviderFilter('bt');
+    sut.setProviderFilter(3);
     sut.setProductFilter('broadband');
     sut.setProductFilter('tv');
 

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -62,4 +62,16 @@ describe("filter", () => {
     expect(sut.deals.length).toEqual(1);
     expect(sut.deals[0].id).toEqual(6468);
   });
+
+  it('should return 2 deals when filtered by BT, broadband and tv', () => {
+    // Act
+    sut.setProviderFilter('bt');
+    sut.setProductFilter('broadband');
+    sut.setProductFilter('tv');
+
+    // Assert
+    expect(sut.deals.length).toEqual(2);
+    expect(sut.deals[0].id).toEqual(6074);
+    expect(sut.deals[1].id).toEqual(5738);
+  });
 });

--- a/src/scripts/__tests__/Store.js
+++ b/src/scripts/__tests__/Store.js
@@ -12,5 +12,6 @@ describe("filter", () => {
 
     // Assert
     expect(result).toEqual(mockData.deals);
+    expect(result.length).toEqual(11);
   });
 });


### PR DESCRIPTION
- WHEN no filters applied THEN show all 11 deals
- WHEN filtering by broadband THEN show the 4 broadband only deals
- WHEN filtering by broadband AND tv THEN show the 4 deals for broadband and tv only
- WHEN filtering by broadband AND mobile THEN show the 1 deal for broadband and mobile only
- WHEN filtering by Sky THEN show the 1 deal for Sky only
- WHEN filtering by BT, broadband AND tv THEN show the 2 deals for BT with broadband and tv only